### PR TITLE
Fix error "ResizeObserver loop limit exceeded" in Chrome

### DIFF
--- a/src/ContainerQueryCore.ts
+++ b/src/ContainerQueryCore.ts
@@ -6,14 +6,17 @@ import isShallowEqual from './isShallowEqual';
 export default class ContainerQueryCore {
   private rol: ResizeObserverLite;
   private result: Params = {};
+  private requestID: number | null = null;
 
   constructor(query: Query, callback: (params: Params) => void) {
     this.rol = new ResizeObserverLite((size) => {
-      const result = matchQueries(query)(size);
-      if (!isShallowEqual(this.result, result)) {
-        callback(result);
-        this.result = result;
-      }
+      this.requestID = window.requestAnimationFrame(() => {
+        const result = matchQueries(query)(size);
+        if (!isShallowEqual(this.result, result)) {
+          callback(result);
+          this.result = result;
+        }
+      });
     });
   }
 
@@ -22,6 +25,7 @@ export default class ContainerQueryCore {
   }
 
   disconnect() {
+    this.requestID !== null && window.cancelAnimationFrame(this.requestID);
     this.rol.disconnect();
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "declaration": true,
     "declarationDir": "lib",
+    "lib": ["dom", "es5"],
     "module": "commonjs",
     "noImplicitAny": true,
     "noImplicitThis": true,


### PR DESCRIPTION
This error appears in Chrome if the `ResizeObserver` callback is executed too frequently. This fix limits its execution with `requestAnimationFrame`.

Fixes #70

The error is not normally visible in Chrome’s console, only with `window.addEventListener('error', e => console.error(e))`.