### PR TITLE
Fix circle CI 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,6 @@
 version: 2
 jobs:
   build:
-    filters:
-      branches:
-        only:
-          - fix-circle-ci
     docker:
       # specify the version you desire here
       - image: circleci/node:12.14

--- a/config/saucelabs-browsers.js
+++ b/config/saucelabs-browsers.js
@@ -20,7 +20,7 @@ module.exports = {
   sl_safari_11: {
     base: 'SauceLabs',
     browserName: 'safari',
-    platform: 'OS X 10.12',
+    platform: 'OS X 10.13',
     version: '11'
   },
   sl_ios_safari_10: {


### PR DESCRIPTION
There's a problem with SauceLabs Safari 11 / Mac OS X 10.12 pairing, but they recommend just using the Max OS X 10.13 Safari 11 instead. https://github.com/novnc/noVNC/issues/1125#issuecomment-413102725.

Also, while running CI, I had a warning that the `filters` prop was extranrous, so I removed that.