### PR TITLE
Fix CircleCI badge, update package links to use github organization in path

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 **True modularity in styling responsive component.**
 
 [![npm version](https://badge.fury.io/js/react-container-query.svg)](https://badge.fury.io/js/react-container-query)
-[![Circle CI](https://circleci.com/gh/d6u/react-container-query/tree/master.svg?style=svg)](https://circleci.com/gh/d6u/react-container-query/tree/master)
+[![Circle CI](https://circleci.com/gh/react-container-query/react-container-query/tree/master.svg?style=svg)](https://circleci.com/gh/react-container-query/react-container-query/tree/master)
 [![Build Status](https://saucelabs.com/buildstatus/react-cq)](https://saucelabs.com/beta/builds/de7d8039f4e5417399ec27c39036c1b8)
-[![codecov](https://codecov.io/gh/d6u/react-container-query/branch/master/graph/badge.svg)](https://codecov.io/gh/d6u/react-container-query)
+[![codecov](https://codecov.io/gh/react-container-query/react-container-query/branch/master/graph/badge.svg)](https://codecov.io/gh/react-container-query/react-container-query)
 
 [![Build Status](https://saucelabs.com/browser-matrix/react-cq.svg)](https://saucelabs.com/beta/builds/de7d8039f4e5417399ec27c39036c1b8)
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Daiwei Lu <daiweilu123@gmail.com> (http://daiwei.lu)",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/d6u/react-container-query.git"
+    "url": "git+https://github.com/react-container-query/react-container-query.git"
   },
   "keywords": [
     "reactjs",
@@ -17,9 +17,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/d6u/react-container-query/issues"
+    "url": "https://github.com/react-container-query/react-container-query/issues"
   },
-  "homepage": "https://github.com/d6u/react-container-query",
+  "homepage": "https://github.com/react-container-query/react-container-query",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [


### PR DESCRIPTION
This should fix the CircleCI badge on the README, along with some links in package.json