### PR TITLE
Prefix unsafe lifecycle methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-container-query",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Container Query for React Component",
   "author": "Daiwei Lu <daiweilu123@gmail.com> (http://daiwei.lu)",
   "repository": {

--- a/scripts/watch/test.sh
+++ b/scripts/watch/test.sh
@@ -3,9 +3,9 @@
 export NODE_ENV=test
 
 rm -rf lib coverage
-tsc
+./node_modules/.bin/tsc
 
-tsc -w &
-karma start --no-single-run &
+./node_modules/.bin/tsc -w &
+./node_modules/.bin/karma start --no-single-run &
 
 wait

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,7 +30,7 @@ export class ContainerQuery extends React.Component<Props, State> {
     this._startObserving(this.props.query);
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
     // componentWillReceiveProps and componentDidMount can potentially run out of order,
     // so we need to consider the case where cqCore is not initialized yet.
     if (this.cqCore && !isQueriesEqual(this.props.query, nextProps.query)) {
@@ -40,7 +40,7 @@ export class ContainerQuery extends React.Component<Props, State> {
     }
   }
 
-  componentDidUpdate() {
+  UNSAFE_componentDidUpdate() {
     this.cqCore!.observe(ReactDOM.findDOMNode(this));
   }
 
@@ -102,7 +102,7 @@ export function applyContainerQuery<T>(
       this.cqCore.observe(ReactDOM.findDOMNode(this));
     }
 
-    componentDidUpdate() {
+    UNSAFE_componentDidUpdate() {
       this.cqCore!.observe(ReactDOM.findDOMNode(this));
     }
 
@@ -133,7 +133,7 @@ function isQueriesEqual(queryA: Query, queryB: Query): boolean {
   }
 
   for (let i = 0; i < keysA.length; i++) {
-    if (!hasOwnProperty.call(queryB, keysA[i]) || 
+    if (!hasOwnProperty.call(queryB, keysA[i]) ||
       !isShallowEqual(queryA[keysA[i]], queryB[keysA[i]])) {
       return false;
     }


### PR DESCRIPTION
* Prefix [legacy lifecycle methods](https://reactjs.org/docs/react-component.html) with UNSAFE
* Update scripts/watch/test.sh with paths for `tsc` and `karma`, so it works again
* Patch version bump