### PR TITLE
Remove UNSAFE_ prefix for componentDidUpdate

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -40,7 +40,7 @@ export class ContainerQuery extends React.Component<Props, State> {
     }
   }
 
-  UNSAFE_componentDidUpdate() {
+  componentDidUpdate() {
     this.cqCore!.observe(ReactDOM.findDOMNode(this));
   }
 
@@ -102,7 +102,7 @@ export function applyContainerQuery<T>(
       this.cqCore.observe(ReactDOM.findDOMNode(this));
     }
 
-    UNSAFE_componentDidUpdate() {
+    componentDidUpdate() {
       this.cqCore!.observe(ReactDOM.findDOMNode(this));
     }
 


### PR DESCRIPTION
UNSAFE_ lifecycles are componentWillMount, componentWillReceiveProps, componentWillUpdate
https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html